### PR TITLE
Implemented custom endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ as below
     'container' => env('OVH_CONTAINER'),
     'projectId' => env('OVH_PROJECT_ID'),
     'urlKey' => env('OVH_URL_KEY'),
+    'endpoint' => env('OVH_CUSTOM_ENDPOINT'),
 ],
 ```
 

--- a/src/OVHServiceProvider.php
+++ b/src/OVHServiceProvider.php
@@ -38,10 +38,10 @@ class OVHServiceProvider extends ServiceProvider
     /**
      * Check that the config is properly setup.
      *
-     * @param  array &$config
+     * @param  array $config
      * @return void|BadMethodCallException
      */
-    protected function checkConfig(&$config)
+    protected function checkConfig($config)
     {
         // needed keys
         $needKeys = ['server', 'region', 'user', 'pass', 'tenantName', 'projectId', 'container'];
@@ -57,10 +57,10 @@ class OVHServiceProvider extends ServiceProvider
     /**
      * Make the client needed for interaction with OVH OpenStack.
      *
-     * @param  array &$config
+     * @param  array $config
      * @return \OpenStack\OpenStack
      */
-    protected function makeClient(&$config)
+    protected function makeClient($config)
     {
         // this is needed because default setup of openstack leads to authentication
         // going to wrong path of the auth url as OVH uses deprecated version
@@ -93,6 +93,7 @@ class OVHServiceProvider extends ServiceProvider
             'projectId' => $config['projectId'],
             'container' => $config['container'],
             'urlKey' => isset($config['urlKey']) ? $config['urlKey'] : null,
+            'endpoint' => isset($config['endpoint']) ? $config['endpoint'] : null,
         ];
     }
 }

--- a/src/OVHSwiftAdapter.php
+++ b/src/OVHSwiftAdapter.php
@@ -44,7 +44,7 @@ class OVHSwiftAdapter extends SwiftAdapter
     {
         $this->checkParams();
 
-        return $this->getEndpoint() . $path;
+        return $this->getEndpoint().$path;
     }
 
     /**
@@ -64,7 +64,7 @@ class OVHSwiftAdapter extends SwiftAdapter
 
         $this->checkParams();
 
-        return $this->getEndpoint() . $path;
+        return $this->getEndpoint().$path;
     }
 
     /**
@@ -102,7 +102,7 @@ class OVHSwiftAdapter extends SwiftAdapter
         // return the url
         return sprintf(
             '%s?temp_url_sig=%s&temp_url_expires=%s',
-            $this->getEndpoint() . $path,
+            $this->getEndpoint().$path,
             $signature,
             $expiresAt
         );
@@ -129,7 +129,7 @@ class OVHSwiftAdapter extends SwiftAdapter
             );
 
         // ensures there's one trailing slash for endpoint
-        return rtrim($endpoint, '/') . '/';
+        return rtrim($endpoint, '/').'/';
     }
 
     /**

--- a/src/OVHSwiftAdapter.php
+++ b/src/OVHSwiftAdapter.php
@@ -44,14 +44,7 @@ class OVHSwiftAdapter extends SwiftAdapter
     {
         $this->checkParams();
 
-        $urlBasePath = sprintf(
-            'https://storage.%s.cloud.ovh.net/v1/AUTH_%s/%s/',
-            $this->urlVars['region'],
-            $this->urlVars['projectId'],
-            $this->urlVars['container']
-        );
-
-        return $urlBasePath.$path;
+        return $this->getEndpoint() . $path;
     }
 
     /**
@@ -71,14 +64,7 @@ class OVHSwiftAdapter extends SwiftAdapter
 
         $this->checkParams();
 
-        $urlBasePath = sprintf(
-            'https://storage.%s.cloud.ovh.net/v1/AUTH_%s/%s/',
-            $this->urlVars['region'],
-            $this->urlVars['projectId'],
-            $this->urlVars['container']
-        );
-
-        return $urlBasePath.$path;
+        return $this->getEndpoint() . $path;
     }
 
     /**
@@ -115,12 +101,35 @@ class OVHSwiftAdapter extends SwiftAdapter
 
         // return the url
         return sprintf(
-            '%s%s?temp_url_sig=%s&temp_url_expires=%s',
-            sprintf('https://storage.%s.cloud.ovh.net', $this->urlVars['region']),
-            $codePath,
+            '%s?temp_url_sig=%s&temp_url_expires=%s',
+            $this->getEndpoint() . $path,
             $signature,
             $expiresAt
         );
+    }
+
+    /**
+     * Gets the endpoint url of the bucket.
+     *
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        $this->checkParams();
+
+        $endpoint = isset($this->urlVars['endpoint'])
+            // allows assigning custom endpoint url
+            ? $this->urlVars['endpoint']
+            // if no custom endpoint assigned, use traditional swift v1 endpoint
+            : sprintf(
+                'https://storage.%s.cloud.ovh.net/v1/AUTH_%s/%s/',
+                $this->urlVars['region'],
+                $this->urlVars['projectId'],
+                $this->urlVars['container']
+            );
+
+        // ensures there's one trailing slash for endpoint
+        return rtrim($endpoint, '/') . '/';
     }
 
     /**
@@ -131,7 +140,7 @@ class OVHSwiftAdapter extends SwiftAdapter
      */
     protected function checkParams()
     {
-        if (! is_array($this->urlVars) || count($this->urlVars) !== 4) {
+        if (! is_array($this->urlVars) || count($this->urlVars) !== 5) {
             throw new BadMethodCallException('Insufficient Url Params', 1);
         }
     }

--- a/tests/BasicAdapterTest.php
+++ b/tests/BasicAdapterTest.php
@@ -17,7 +17,7 @@ class BasicAdapterTest extends \PHPUnit_Framework_TestCase
             'projectId' => 'projectId',
             'container' => 'container',
             'urlKey' => 'meykey',
-            'endpoint' => null
+            'endpoint' => null,
         ];
 
         $this->container = Mockery::mock('OpenStack\ObjectStore\v1\Models\Container');

--- a/tests/BasicAdapterTest.php
+++ b/tests/BasicAdapterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Sausin\LaravelOvh\Tests;
+
+use Mockery;
+use Carbon\Carbon;
+use League\Flysystem\Config;
+use Sausin\LaravelOvh\OVHSwiftAdapter;
+
+class BasicAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->config = new Config([]);
+        $this->urlVars = [
+            'region' => 'region',
+            'projectId' => 'projectId',
+            'container' => 'container',
+            'urlKey' => 'meykey',
+            'endpoint' => null
+        ];
+
+        $this->container = Mockery::mock('OpenStack\ObjectStore\v1\Models\Container');
+
+        $this->container->name = 'container-name';
+        $this->object = Mockery::mock('OpenStack\ObjectStore\v1\Models\StorageObject');
+        $this->adapter = new OVHSwiftAdapter($this->container, $this->urlVars);
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testUrlConfirmMethod()
+    {
+        $this->object->shouldReceive('retrieve')->once();
+        $this->object->name = 'hello/world';
+        $this->object->lastModified = date('Y-m-d');
+        $this->object->contentType = 'mimetype';
+        $this->object->contentLength = 1234;
+
+        $this->container
+                ->shouldReceive('getObject')
+                ->once()
+                ->with('hello')
+                ->andReturn($this->object);
+
+        $url = $this->adapter->getUrlConfirm('hello');
+
+        $this->assertEquals($url, 'https://storage.region.cloud.ovh.net/v1/AUTH_projectId/container/hello');
+    }
+
+    public function testUrlMethod()
+    {
+        $this->object->shouldNotReceive('retrieve');
+        $this->container->shouldNotReceive('getObject');
+
+        $url = $this->adapter->getUrl('hello');
+
+        $this->assertEquals($url, 'https://storage.region.cloud.ovh.net/v1/AUTH_projectId/container/hello');
+    }
+
+    public function testTemporaryUrlMethod()
+    {
+        $this->object->shouldNotReceive('retrieve');
+        $this->container->shouldNotReceive('getObject');
+
+        $url = $this->adapter->getTemporaryUrl('hello.jpg', Carbon::now()->addMinutes(10));
+
+        $this->assertNotNull($url);
+    }
+}

--- a/tests/CustomEndpointTest.php
+++ b/tests/CustomEndpointTest.php
@@ -17,7 +17,7 @@ class CustomEndpointTest extends \PHPUnit_Framework_TestCase
             'projectId' => 'projectId',
             'container' => 'container',
             'urlKey' => 'meykey',
-            'endpoint' => 'http://custom.endpoint'
+            'endpoint' => 'http://custom.endpoint',
         ];
 
         $this->container = Mockery::mock('OpenStack\ObjectStore\v1\Models\Container');

--- a/tests/CustomEndpointTest.php
+++ b/tests/CustomEndpointTest.php
@@ -7,7 +7,7 @@ use Carbon\Carbon;
 use League\Flysystem\Config;
 use Sausin\LaravelOvh\OVHSwiftAdapter;
 
-class OVHSwiftAdapterTest extends \PHPUnit_Framework_TestCase
+class CustomEndpointTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -17,6 +17,7 @@ class OVHSwiftAdapterTest extends \PHPUnit_Framework_TestCase
             'projectId' => 'projectId',
             'container' => 'container',
             'urlKey' => 'meykey',
+            'endpoint' => 'http://custom.endpoint'
         ];
 
         $this->container = Mockery::mock('OpenStack\ObjectStore\v1\Models\Container');
@@ -47,7 +48,7 @@ class OVHSwiftAdapterTest extends \PHPUnit_Framework_TestCase
 
         $url = $this->adapter->getUrlConfirm('hello');
 
-        $this->assertEquals($url, 'https://storage.region.cloud.ovh.net/v1/AUTH_projectId/container/hello');
+        $this->assertEquals($url, 'http://custom.endpoint/hello');
     }
 
     public function testUrlMethod()
@@ -57,7 +58,7 @@ class OVHSwiftAdapterTest extends \PHPUnit_Framework_TestCase
 
         $url = $this->adapter->getUrl('hello');
 
-        $this->assertEquals($url, 'https://storage.region.cloud.ovh.net/v1/AUTH_projectId/container/hello');
+        $this->assertEquals($url, 'http://custom.endpoint/hello');
     }
 
     public function testTemporaryUrlMethod()


### PR DESCRIPTION
Enables the use of custom endpoints in case the user has configured a custom domain name behind a DNS (i.e. Cloudflare).

Setup on `config/filesystems` can now include:
```diff
'ovh' => [
    'server' => env('OVH_URL'),
    'driver' => 'ovh',
    'user' => env('OVH_USER'),
    'pass' => env('OVH_PASS'),
    'region' => env('OVH_REGION'),
    'tenantName' => env('OVH_TENANT_NAME'),
    'container' => env('OVH_CONTAINER'),
    'projectId' => env('OVH_PROJECT_ID'),
    'urlKey' => env('OVH_URL_KEY'),
+    'endpoint' => env('OVH_CUSTOM_ENDPOINT'),
],
```

Using the endpoint `http://my-awesome.endpoint` on the `OVH_CUSTOM_ENDPOINT` env variable, we should expect...
```php
/** @var \Illuminate\Filesystem\FilesystemAdapter $storage */
$storage = Storage::disk('ovh');

$storage->url('path/to/my/file');
// returns 'http://my-awesome.endpoint/path/to/my/file'

$storage->temporaryUrl('path/to/my/file', now()->addSeconds(1));
// returns 'http://my-awesome.endpoint/path/to/my/file?temp_url_sig=r4nd0ms1gn4tur3&temp_url_expires=...'
```

Also, added corresponding test configurations w/o custom endpoint :smile:.