### PR TITLE
Support for keystone v3 in OVH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 install:
   - travis_retry composer update

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install via composer:
 composer require sausin/laravel-ovh
 ```
 Note: Branch 1.2.x works for PHP versions < 7.2
-
+Note: Branch 2.x works with soon to be deprecated v2 of the OVH keystone API
 
 Then include the service provider in config/app.php
 ```php
@@ -36,8 +36,8 @@ as below
     'driver' => 'ovh',
     'user' => env('OVH_USER'),
     'pass' => env('OVH_PASS'),
+    'userDomain' => env('OVH_USER_DOMAIN', 'Default'),
     'region' => env('OVH_REGION'),
-    'tenantName' => env('OVH_TENANT_NAME'),
     'container' => env('OVH_CONTAINER'),
     'projectId' => env('OVH_PROJECT_ID'),
     'urlKey' => env('OVH_URL_KEY'),

--- a/src/OVHServiceProvider.php
+++ b/src/OVHServiceProvider.php
@@ -2,15 +2,12 @@
 
 namespace Sausin\LaravelOvh;
 
+
+use OpenStack\OpenStack;
 use BadMethodCallException;
-use GuzzleHttp\Client;
-use GuzzleHttp\HandlerStack;
+use League\Flysystem\Filesystem;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
-use League\Flysystem\Filesystem;
-use OpenStack\Common\Transport\Utils as TransportUtils;
-use OpenStack\Identity\v2\Service;
-use OpenStack\OpenStack;
 
 class OVHServiceProvider extends ServiceProvider
 {
@@ -44,7 +41,7 @@ class OVHServiceProvider extends ServiceProvider
     protected function checkConfig($config)
     {
         // needed keys
-        $needKeys = ['server', 'region', 'user', 'pass', 'tenantName', 'projectId', 'container'];
+        $needKeys = ['server', 'region', 'user', 'pass', 'userDomain', 'projectId', 'container'];
 
         if (count(array_intersect($needKeys, array_keys($config))) === count($needKeys)) {
             return;
@@ -62,21 +59,20 @@ class OVHServiceProvider extends ServiceProvider
      */
     protected function makeClient($config)
     {
-        // this is needed because default setup of openstack leads to authentication
-        // going to wrong path of the auth url as OVH uses deprecated version
-        $httpClient = new Client([
-            'base_uri' => TransportUtils::normalizeUrl($config['server']),
-            'handler'  => HandlerStack::create(),
-        ]);
-
-        // setup the client for OpenStack v1
+        // setup the client for OpenStack
         return new OpenStack([
             'authUrl' => $config['server'],
             'region' => $config['region'],
-            'username' => $config['user'],
-            'password' => $config['pass'],
-            'tenantName' => $config['tenantName'],
-            'identityService' => Service::factory($httpClient),
+            'user' => [
+                'name' => $config['user'],
+                'password' => $config['pass'],
+                'domain' => ['name' => 'userDomain'],
+            ],
+            'scope' => [
+                'project' => [
+                    'id' => $config['projectId']
+                ]
+            ],
         ]);
     }
 


### PR DESCRIPTION
As identified in #20 the current version of the package is not able to work with the v3 API. 

This PR fixes this issue. Since there are a lot of changes to the basic setup of the `OVHServiceProvider` class, this will be moved to new series of the package.