### PR TITLE
Fix PHP version setup for Github Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v1
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
       - name: Install dependencies
         run: |
           composer require "illuminate/support:${{ matrix.illuminate }}" --no-interaction --no-update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,17 @@ jobs:
         php: [7.1, 7.2, 7.3, 7.4]
         illuminate: [5.4.*, 5.5.*, 5.6.*, 5.7.*, 5.8.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - illuminate: 6.*
+            php: 7.1
+          - illuminate: 5.7.*
+            php: 7.4
+          - illuminate: 5.6.*
+            php: 7.4
+          - illuminate: 5.5.*
+            php: 7.4
+          - illuminate: 5.4.*
+            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.illuminate }}
 


### PR DESCRIPTION
Based on [this post by Freek](https://freek.dev/1546-using-github-actions-to-run-the-tests-of-laravel-projects-and-packages).

Also, checkout [the repo for `setup-php` action](https://github.com/shivammathur/setup-php)