### PR TITLE
add Command to CreateTempUrlKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Laravel OVH Object Storage driver
 
-
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/sausin/laravel-ovh.svg?style=flat-square)](https://packagist.org/packages/sausin/laravel-ovh)
 [![](https://github.com/sausin/laravel-ovh/workflows/CI%20laravel-ovh/badge.svg?branch=master)](https://github.com/sausin/laravel-ovh/actions?query=workflow%3A%22CI+laravel-ovh%22)
 [![Quality Score](https://img.shields.io/scrutinizer/g/sausin/laravel-ovh.svg?style=flat-square)](https://scrutinizer-ci.com/g/sausin/laravel-ovh)
 [![StyleCI](https://styleci.io/repos/85194981/shield?branch=master)](https://styleci.io/repos/85194981)
 [![Total Downloads](https://img.shields.io/packagist/dt/sausin/laravel-ovh.svg?style=flat-square)](https://packagist.org/packages/sausin/laravel-ovh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
-
 
 Laravel `Storage` facade provides support for many different filesystems.
 
@@ -16,19 +14,24 @@ This is a wrapper to combine others' work to integrate with laravel and provide 
 # Installing
 
 Install via composer:
+
 ```
 composer require sausin/laravel-ovh
 ```
+
 Note: Branch 1.2.x works for PHP versions < 7.2 and branch 2.x works with soon to be deprecated v2 of the OVH keystone API
 
 Then include the service provider in `config/app.php`
+
 ```php
 Sausin\LaravelOvh\OVHServiceProvider::class
 ```
+
 in the providers array. This step is not required for Laravel 5.5 and above as the service provider is automatically registered!
 
 Define the ovh driver in the `config/filesystems.php`
 as below
+
 ```php
 'ovh' => [
     'server' => env('OVH_URL'),
@@ -39,6 +42,7 @@ as below
     'region' => env('OVH_REGION'),
     'container' => env('OVH_CONTAINER'),
     'projectId' => env('OVH_PROJECT_ID'),
+    'tenantName' => env('OVH_TENANT_NAME'),
     'urlKey' => env('OVH_URL_KEY'),
     'endpoint' => env('OVH_CUSTOM_ENDPOINT'),
     // optional variables for handling large objects
@@ -51,11 +55,12 @@ as below
 define the correct env variables above in your .env file (to correspond to the values above) and you should now have a working OVH Object Storage setup :)
 
 Be sure to run
+
 ```
 php artisan config:cache
 ```
-again if you've been using the caching on your config file.
 
+again if you've been using the caching on your config file.
 
 # Usage
 
@@ -76,6 +81,7 @@ Note that this requires the container to have a proper header. The key in the he
 If you would like to upload objects which expire (is auto deleted) at a certain time in future, you can add `deleteAt` or `deleteAfter` configuration options when uploading the object.
 
 For eg, below code will upload a file which expires after one hour:
+
 ```php
 Storage::disk('ovh')->put('path/to/file.jpg', $contents, ['deleteAfter' => 60*60])
 ```
@@ -83,6 +89,7 @@ Storage::disk('ovh')->put('path/to/file.jpg', $contents, ['deleteAfter' => 60*60
 Usage of these variables is explained in the OVH documentation [here](https://github.com/ovh/docs/blob/develop/pages/platform/public-cloud/setup_automatic_deletion_of_objects/guide.en-gb.md)
 
 # Credits
+
 - thephpleage for the awesome [flysystem](https://github.com/thephpleague/flysystem)!
 - [SwiftAdapter](https://github.com/nimbusoftltd/flysystem-openstack-swift) by Nimbusoft
 - Rackspace for maintaining the [Openstack repo](https://github.com/php-opencloud/openstack)

--- a/src/Commands/CreateTempUrlKey.php
+++ b/src/Commands/CreateTempUrlKey.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Sausin\LaravelOvh\Commands;
+
+use Illuminate\Console\Command;
+
+class CreateTempUrlKey extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ovh:create-temp-url-key';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate the temp url key, allowing the use of Storage::temporaryUrl()';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // generate the key with sha512sum of time()
+
+        $this->info("read https://docs.ovh.com/gb/en/public-cloud/share_an_object_via_a_temporary_url/#generate-the-key for explanation of what we're doing here");
+
+        $temp_url_key = hash('sha512', time());
+        $client = new \GuzzleHttp\Client();
+
+        // ( https://docs.ovh.com/gb/en/public-cloud/managing_tokens/ )
+        // Request token creation
+        //  curl -X POST ${OS_AUTH_URL}auth/tokens -H "Content-Type: application/json" -d ' { "auth": { "identity": { "methods": ["password"], "password": { "user": { "name": "'$OS_USERNAME'", "domain": { "id": "default" }, "password": "'$OS_PASSWORD'" } } }, "scope": { "project": { "name": "'$OS_TENANT_NAME'", "domain": { "id": "default" } } } } }' | python -mjson.tool
+
+        $payload = [
+            "auth" =>   [
+                "identity"  => [
+                    "methods"   =>  [
+                        "password"
+                    ],
+                    "password" => [
+                        "user"  =>  [
+                            "name"      => config('filesystems.disks.ovh.user'),
+                            "domain"    => [
+                                "id"    => "default"
+                            ],
+                            "password" => config('filesystems.disks.ovh.pass')
+                        ]
+                    ]
+                ],
+                "scope" =>  [
+                    "project" => [
+                        "name" => config('filesystems.disks.ovh.tenantName'),
+                        "domain" => [
+                            "id" => "default"
+                        ]
+                    ]
+                ]
+            ],
+        ];
+
+        $this->info("getting auth token from ".config('filesystems.disks.ovh.server').'auth/tokens');
+
+        $response = $client->request('POST', config('filesystems.disks.ovh.server').'auth/tokens', [
+            'json'   =>  $payload
+        ]);
+
+        $data = json_decode($response->getBody());
+
+        // Retrieve the token ID variables and publicURL endpoint
+        foreach($data->token->catalog as $catalog):
+            if ( $catalog->type == 'object-store' ):
+                foreach($catalog->endpoints as $endpoint):
+                    if ( $endpoint->region == config('filesystems.disks.ovh.region') ):
+                        // $auth_token = $endpoint->id;
+                        $endpoint = $endpoint->url;
+                        break(2);
+                    endif;
+                endforeach;
+            endif;
+        endforeach;
+
+        // export token=$(curl -is -X POST ${OS_AUTH_URL}auth/tokens -H "Content-Type: application/json" -d ' { "auth": { "identity": { "methods": ["password"], "password": { "user": { "name": "'$OS_USERNAME'", "domain": { "id": "default" }, "password": "'$OS_PASSWORD'" } } }, "scope": { "project": { "name": "'$OS_TENANT_NAME'", "domain": { "id": "default" } } } } }' | grep '^X-Subject-Token' | cut -d" " -f2)
+        $headers = $response->getHeaders();
+        $auth_token = $headers["X-Subject-Token"][0];
+
+
+        // then define the temp-url-key header ( https://docs.ovh.com/gb/en/public-cloud/share_an_object_via_a_temporary_url/#generate-the-key )
+        // curl -i -X POST \ -H "X-Account-Meta-Temp-URL-Key: 12345" \ -H "X-Auth-Token: abcdef12345" \ https://storage.sbg1.cloud.ovh.net/v1/AUTH_ProjectID
+
+        $payload = [
+            'headers'   =>  [
+                'X-Account-Meta-Temp-URL-Key'   =>  $temp_url_key,
+                'X-Auth-Token'                  =>  $auth_token
+            ]
+        ];
+        $this->info("posting to ".$endpoint);
+
+        $response = $client->request('POST', $endpoint, $payload);
+
+        $this->alert("add this line to your .env file");
+        $this->info("OVH_URL_KEY=".$temp_url_key.PHP_EOL);
+
+    }
+
+
+
+}

--- a/src/OVHServiceProvider.php
+++ b/src/OVHServiceProvider.php
@@ -32,6 +32,12 @@ class OVHServiceProvider extends ServiceProvider
                 $this->getLargeObjectConfig($config)
             );
         });
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                Commands\CreateTempUrlKey::class
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
this PR add a 'ovh:create-temp-url-key' command to automate the step described in https://docs.ovh.com/gb/en/public-cloud/share_an_object_via_a_temporary_url/#generate-the-key

it needs a new env variable OVH_TENANT_NAME which appears in the Openstack's RC as OS_TENANT_NAME

