### PR TITLE
Support custom disk names for commands

### DIFF
--- a/src/Commands/SetCORSHeaders.php
+++ b/src/Commands/SetCORSHeaders.php
@@ -4,6 +4,7 @@ namespace Sausin\LaravelOvh\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
 use League\Flysystem\Cached\CachedAdapter;
@@ -27,7 +28,7 @@ class SetCORSHeaders extends Command
      *
      * @var string
      */
-    protected $description = 'Set CORS headers on the container to make Form POST signaure work flawlessly';
+    protected $description = 'Set CORS headers on the container to make Form POST signature work flawlessly';
 
     /**
      * The Object Storage Container.
@@ -50,7 +51,9 @@ class SetCORSHeaders extends Command
     public function handle(): void
     {
         try {
-            $adapter = Storage::disk($this->option('disk'))->getAdapter();
+            $disk = $this->getDisk();
+
+            $adapter = Storage::disk($disk)->getAdapter();
 
             if ($adapter instanceof CachedAdapter) {
                 $adapter = $adapter->getAdapter();
@@ -120,5 +123,28 @@ class SetCORSHeaders extends Command
         } catch (Exception $e) {
             $this->error($e->getMessage());
         }
+    }
+
+    /**
+     * Check if selected disk is correct. If not, provide options to user.
+     *
+     * @return string
+     */
+    public function getDisk(): string
+    {
+        $available = array_keys(array_filter(Config::get('filesystems.disks'), function ($d) {
+            return $d['driver'] === 'ovh';
+        }));
+
+        $selected = $this->option('disk');
+
+        if (in_array($selected, $available)) {
+            return $selected;
+        }
+
+        return $this->choice(
+            'Selected disk not correct. Please choose from below options:',
+            $available,
+        );
     }
 }

--- a/src/Commands/SetTempUrlKey.php
+++ b/src/Commands/SetTempUrlKey.php
@@ -4,6 +4,7 @@ namespace Sausin\LaravelOvh\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
 use League\Flysystem\Cached\CachedAdapter;
@@ -52,7 +53,9 @@ class SetTempUrlKey extends Command
     public function handle(): void
     {
         try {
-            $adapter = Storage::disk($this->option('disk'))->getAdapter();
+            $disk = $this->getDisk();
+
+            $adapter = Storage::disk($disk)->getAdapter();
 
             if ($adapter instanceof CachedAdapter) {
                 $adapter = $adapter->getAdapter();
@@ -142,5 +145,28 @@ class SetTempUrlKey extends Command
         }
 
         return $meta;
+    }
+
+    /**
+     * Check if selected disk is correct. If not, provide options to user.
+     *
+     * @return string
+     */
+    public function getDisk(): string
+    {
+        $available = array_keys(array_filter(Config::get('filesystems.disks'), function ($d) {
+            return $d['driver'] === 'ovh';
+        }));
+
+        $selected = $this->option('disk');
+
+        if (in_array($selected, $available)) {
+            return $selected;
+        }
+
+        return $this->choice(
+            'Selected disk not correct. Please choose from below options:',
+            $available,
+        );
     }
 }


### PR DESCRIPTION
Closes item remaining in #48 

Ideally, the method `getDisk()` should be a trait, but for now keeping it duplicate.