### PR TITLE
Change swiftSegmentSize config from string to int.

### DIFF
--- a/src/OVHConfiguration.php
+++ b/src/OVHConfiguration.php
@@ -105,9 +105,9 @@ class OVHConfiguration
      *
      * Returns NULL if disabled.
      *
-     * @return string|null
+     * @return int|null
      */
-    protected ?string $swiftSegmentSize;
+    protected ?int $swiftSegmentSize;
 
     /**
      * OPTIONAL.
@@ -374,18 +374,18 @@ class OVHConfiguration
     }
 
     /**
-     * @return string|null
+     * @return int|null
      */
-    public function getSwiftSegmentSize(): ?string
+    public function getSwiftSegmentSize(): ?int
     {
         return $this->swiftSegmentSize;
     }
 
     /**
-     * @param string|null $swiftSegmentSize
+     * @param int|null $swiftSegmentSize
      * @return OVHConfiguration
      */
-    public function setSwiftSegmentSize(?string $swiftSegmentSize): self
+    public function setSwiftSegmentSize(?int $swiftSegmentSize): self
     {
         $this->swiftSegmentSize = $swiftSegmentSize;
 


### PR DESCRIPTION
When uploading a large object the `swiftSegmentSize` config option gets passed around until it gets used to create a [GuzzleHttp\Psr7\LimitStream](https://github.com/guzzle/psr7/blob/master/src/LimitStream.php#L31), where it must be an integer. Having it as a string causes a `TypeError`.

I'm not sure when this changed, everything was working fine for me, but I updated some dependencies today and must have pulled in a new version of of either sausin/laravel-ovh or php-opencloud/openstack, and now the types don't agree.

It might be logical to change the `swiftLargeObjectThreshold` as an integer too, but it is not causing any problems as a string so I didn't change it.