### PR TITLE
Handle the change in the way $this is bound in Laravel 13.

### DIFF
--- a/src/OVHServiceProvider.php
+++ b/src/OVHServiceProvider.php
@@ -44,21 +44,33 @@ class OVHServiceProvider extends ServiceProvider
      */
     protected function configureStorage(): void
     {
-        Storage::extend('ovh', function ($app, array $config) {
-            // Creates a Configuration instance.
-            $this->config = OVHConfiguration::make($config);
+        // Laravel's FilesystemManager::extend() rebinds the closure's $this to
+        // the manager itself, so capture the provider in a use() variable and
+        // route through a public method.
+        $provider = $this;
 
-            $client = $this->makeOpenStackClient();
-
-            // Get the Object Storage container.
-            $container = $client->objectStoreV1()->getContainer($this->config->getContainerName());
-
-            $adapter = $this->makeAdapter($container);
-
-            $filesystem = $this->makeFileSystem($adapter);
-
-            return new FilesystemAdapter($filesystem, $adapter, $config);
+        Storage::extend('ovh', function ($app, array $config) use ($provider) {
+            return $provider->createDriver($config);
         });
+    }
+
+    /**
+     * Builds the FilesystemAdapter for an 'ovh' disk from its config array.
+     */
+    public function createDriver(array $config): FilesystemAdapter
+    {
+        $this->config = OVHConfiguration::make($config);
+
+        $client = $this->makeOpenStackClient();
+
+        // Get the Object Storage container.
+        $container = $client->objectStoreV1()->getContainer($this->config->getContainerName());
+
+        $adapter = $this->makeAdapter($container);
+
+        $filesystem = $this->makeFileSystem($adapter);
+
+        return new FilesystemAdapter($filesystem, $adapter, $config);
     }
 
     /**

--- a/tests/Functional/ServiceProviderTest.php
+++ b/tests/Functional/ServiceProviderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Sausin\LaravelOvh\Tests\Functional;
+
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use OpenStack\ObjectStore\v1\Models\Container;
+use OpenStack\ObjectStore\v1\Service as ObjectStoreService;
+use OpenStack\OpenStack;
+use Orchestra\Testbench\TestCase;
+use Sausin\LaravelOvh\OVHServiceProvider;
+
+class ServiceProviderTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [TestableOVHServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('filesystems.disks.ovh', [
+            'driver' => 'ovh',
+            'authUrl' => '',
+            'projectId' => 'AwesomeProject',
+            'region' => 'TestingGround',
+            'userDomain' => 'Default',
+            'username' => '',
+            'password' => '',
+            'containerName' => 'my-container',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // Regression: in Laravel 13 FilesystemManager::extend() rebinds the closure's
+    // $this to the manager itself, so the provider must route through a captured
+    // $provider variable. Resolving the disk exercises the registered closure end-to-end.
+    public function testCanResolveOvhDiskThroughStorageExtend(): void
+    {
+        $disk = Storage::disk('ovh');
+
+        $this->assertInstanceOf(FilesystemAdapter::class, $disk);
+    }
+
+    public function testCreateDriverReturnsFilesystemAdapter(): void
+    {
+        $provider = new TestableOVHServiceProvider($this->app);
+
+        $disk = $provider->createDriver([
+            'driver' => 'ovh',
+            'authUrl' => '',
+            'projectId' => 'AwesomeProject',
+            'region' => 'TestingGround',
+            'userDomain' => 'Default',
+            'username' => '',
+            'password' => '',
+            'containerName' => 'my-container',
+        ]);
+
+        $this->assertInstanceOf(FilesystemAdapter::class, $disk);
+    }
+}
+
+class TestableOVHServiceProvider extends OVHServiceProvider
+{
+    protected function makeOpenStackClient(): OpenStack
+    {
+        $container = Mockery::mock(Container::class);
+
+        $objectStore = Mockery::mock(ObjectStoreService::class);
+        $objectStore->shouldReceive('getContainer')
+            ->andReturn($container);
+
+        $client = Mockery::mock(OpenStack::class);
+        $client->shouldReceive('objectStoreV1')
+            ->andReturn($objectStore);
+
+        return $client;
+    }
+}


### PR DESCRIPTION
Hi again @sausin - it turns out I was wrong about just needing to update the composer.json for Laravel 13. L13 changed how $this bound in `Storage::extend`, so calling `$this->makeOpenStackClient()` fails, because `$this` no longer has a `makeOpenStackClient()` method.

This PR fixes the problem by copying the `$this` that we need to a variable and passing it to the closure in `OVHServiceProvider::configureStorage()`. It creates a new method, `OVHServiceProvider::createDriver()` to be called from the closure, if you don't like that I can refactor to put everything into the closure in `configureStorage()`.

Sorry for the false confidence yesterday!